### PR TITLE
added var.create_intra_subnet_route_table

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -796,6 +796,7 @@ resource "aws_network_acl_rule" "elasticache_outbound" {
 
 locals {
   create_intra_subnets = local.create_vpc && local.len_intra_subnets > 0
+  create_intra_route_table = local.create_intra_subnets && var.create_intra_subnet_route_table
 }
 
 resource "aws_subnet" "intra" {
@@ -830,7 +831,7 @@ locals {
 }
 
 resource "aws_route_table" "intra" {
-  count = local.create_intra_subnets ? local.num_intra_route_tables : 0
+  count = local.create_intra_route_table ? local.num_intra_route_tables : 0
 
   vpc_id = local.vpc_id
 
@@ -847,7 +848,7 @@ resource "aws_route_table" "intra" {
 }
 
 resource "aws_route_table_association" "intra" {
-  count = local.create_intra_subnets ? local.len_intra_subnets : 0
+  count = local.create_intra_subnets && local.create_intra_route_table ? local.len_intra_subnets : 0
 
   subnet_id      = element(aws_subnet.intra[*].id, count.index)
   route_table_id = element(aws_route_table.intra[*].id, var.create_multiple_intra_route_tables ? count.index : 0)

--- a/variables.tf
+++ b/variables.tf
@@ -920,6 +920,12 @@ variable "intra_subnet_enable_resource_name_dns_a_record_on_launch" {
   default     = false
 }
 
+variable "create_intra_subnet_route_table" {
+  description = "Controls if separate route table for intra should be created"
+  type        = bool
+  default     = true
+}
+
 variable "create_multiple_intra_route_tables" {
   description = "Indicates whether to create a separate route table for each intra subnet. Default: `false`"
   type        = bool


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added `var.create_intra_subnet_route_table`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By specifying the var.create_intra_subnet_route_table with false,
users can choose not to create the route table for intra subnet.

<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->

There is no breaking changes.

<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
